### PR TITLE
fix: correct package name, master user bypass, and timezone-aware datetime

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -95,7 +95,7 @@ class Metadata(BaseModel):
         Returns the application version.
         """
 
-        return importlib.metadata.version("external-data-gateway")
+        return importlib.metadata.version("octo-data-gateway")
     
     def finish_successful_request(self, error_info: ErrorDetail = None):
         """

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -43,7 +43,7 @@ async def get_api_user(scopes: list[Scopes], request: Request, api_key: str = De
             detail="API Key has expired. It has expired on {}, please request a new one.".format(user.api_key_expires_at),
         )
 
-    if not any(scope in user.scopes for scope in scopes):
+    if not user.is_master and not any(scope in user.scopes for scope in scopes):
         logger.warning("Insufficient permissions. Http 403 Forbidden", extra={
             "required_scopes": [str(s) for s in scopes],
             "user_scopes": [str(s) for s in user.scopes],

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Scopes(str, Enum):
@@ -67,7 +67,7 @@ class User(BaseModel):
     def is_valid(self) -> bool:
         if self.api_key_expires_at is None:
             return True
-        return self.api_key_expires_at > datetime.now()
+        return self.api_key_expires_at > datetime.now(timezone.utc)
     
     
 class UserUsage(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "email_validator>=2.3.0",
     "schwifty>=2025.7.0",
     "rest-health>=0.1.1",
-    "redis[hiredis]>=5.0.0"
+    "redis[hiredis]>=5.0.0",
+    "importlib_metadata>=8.0.0"
 ]
 
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Fix incorrect package name in `importlib.metadata.version` call (`external-data-gateway` → `octo-data-gateway`)
- Allow master users to bypass scope permission checks (resolves 403 errors for master accounts)
- Use timezone-aware `datetime.now(timezone.utc)` for `api_key_expires_at` comparison to avoid runtime warnings

## Test plan
- [ ] Verify app starts without errors in Docker
- [ ] Verify master user can access all endpoints without 403
- [ ] Verify non-master users with correct scopes still have access
- [ ] Verify non-master users with incorrect scopes get 403
- [ ] Verify API key expiration check works correctly with timezone-aware datetime